### PR TITLE
Ansible PPA for Yakkety

### DIFF
--- a/core/Ubuntu/yakkety/Dockerfile
+++ b/core/Ubuntu/yakkety/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        software-properties-common \
        python-software-properties \
+    && apt-add-repository -y ppa:ansible/ansible \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
        ansible \
        rsyslog \


### PR DESCRIPTION
Adding the ppa gets us the most current version of Ansible for yakkety, which was previously unavailable.