### PR TITLE
Add debian 9 (stretch) documentation + build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     run_opts: ""
   - distribution: Debian
     distribution_version: stretch
-    init: /usr/local/bin/davedaemon
+    init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distribution: Debian
     distribution_version: jessie

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ env:
     init: /sbin/init
     run_opts: ""
   - distribution: Debian
+    distribution_version: stretch
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Debian
     distribution_version: jessie
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     run_opts: ""
   - distribution: Debian
     distribution_version: stretch
-    init: /lib/systemd/systemd
+    init: /usr/local/bin/davedaemon
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distribution: Debian
     distribution_version: jessie

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A One Stop Solution For Checking Your Ansible Roles and Playbooks.
 *   [```ubuntu-16.10```, ```ubuntu-yakkety``` (*ubuntu-yakkety/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Ubuntu/yakkety/Dockerfile)
 *   [```debian-8```, ```debian-jessie``` (*debian-jessie/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Debian/jessie/Dockerfile)
 *   [```debian-7```, ```debian-wheezy``` (*debian-jessie/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Debian/wheezy/Dockerfile)
+*   [```debian-7```, ```debian-wheezy``` (*debian-wheezy/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Debian/wheezy/Dockerfile)
 *   [```centos-7```, ```el-7```  (*el-7/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/EL/7/Dockerfile)
 *   [```centos-6```, ```el-6```  (*el-6/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/EL/6/Dockerfile)
 *   [```fedora-24``` (*fedora-24/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Fedora/24/Dockerfile)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A One Stop Solution For Checking Your Ansible Roles and Playbooks.
 *   [```ubuntu-14.04```, ```ubuntu-trusty``` (*ubuntu-trusty/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Ubuntu/trusty/Dockerfile)
 *   [```ubuntu-16.04```, ```ubuntu-xenial``` (*ubuntu-xenial/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Ubuntu/xenial/Dockerfile)
 *   [```ubuntu-16.10```, ```ubuntu-yakkety``` (*ubuntu-yakkety/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Ubuntu/yakkety/Dockerfile)
+*   [```debian-9```, ```debian-stretch``` (*debian-stretch/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Debian/stretch/Dockerfile)
 *   [```debian-8```, ```debian-jessie``` (*debian-jessie/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Debian/jessie/Dockerfile)
-*   [```debian-7```, ```debian-wheezy``` (*debian-jessie/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Debian/wheezy/Dockerfile)
 *   [```debian-7```, ```debian-wheezy``` (*debian-wheezy/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/Debian/wheezy/Dockerfile)
 *   [```centos-7```, ```el-7```  (*el-7/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/EL/7/Dockerfile)
 *   [```centos-6```, ```el-6```  (*el-6/Dockerfile*)](https://github.com/AnsibleCheck/ansiblecheck/blob/master/core/EL/6/Dockerfile)
@@ -124,6 +124,10 @@ You can comment out an environment with # on each line of the list item.
   distribution_version: "6"
   init: /sbin/init
   run_opts: ""
+- distribution: Debian
+  distribution_version: stretch
+  init: /lib/systemd/systemd
+  run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 - distribution: Debian
   distribution_version: jessie
   init: /lib/systemd/systemd

--- a/core/Debian/stretch/Dockerfile
+++ b/core/Debian/stretch/Dockerfile
@@ -22,6 +22,3 @@ RUN apt-get update \
     && mkdir -p /etc/ansible \
     && echo "[local]" > /etc/ansible/hosts \
     && echo "localhost ansible_connection=local" >> /etc/ansible/hosts
-
-COPY davedaemon /usr/local/bin/
-RUN chmod 755 /usr/local/bin/davedaemon

--- a/core/Debian/stretch/Dockerfile
+++ b/core/Debian/stretch/Dockerfile
@@ -22,3 +22,6 @@ RUN apt-get update \
     && mkdir -p /etc/ansible \
     && echo "[local]" > /etc/ansible/hosts \
     && echo "localhost ansible_connection=local" >> /etc/ansible/hosts
+
+COPY davedaemon /usr/local/bin/
+RUN chmod 755 /usr/local/bin/davedaemon

--- a/core/Debian/stretch/Dockerfile
+++ b/core/Debian/stretch/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Christopher Davenport
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+       systemd-sysv \
        sudo \
        build-essential \
        libffi-dev \

--- a/core/Debian/stretch/Dockerfile
+++ b/core/Debian/stretch/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
        python-pip \
        python-dev \
        python-setuptools \
+       python-wheel \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \
     && rm -Rf /usr/share/man \

--- a/core/Debian/stretch/davedaemon
+++ b/core/Debian/stretch/davedaemon
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-while true;
-do
-  echo "Hi, it's Dave; I'm alive!"
-  sleep 1
-done

--- a/core/Debian/stretch/davedaemon
+++ b/core/Debian/stretch/davedaemon
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+while true;
+do
+  echo "Hi, it's Dave; I'm alive!"
+  sleep 1
+done

--- a/docs/examples/simple-playbook/.travis.yml
+++ b/docs/examples/simple-playbook/.travis.yml
@@ -27,6 +27,10 @@ env:
     init: /sbin/init
     run_opts: ""
   - distribution: Debian
+    distribution_version: stretch
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Debian
     distribution_version: jessie
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"

--- a/docs/examples/simple/.travis.yml
+++ b/docs/examples/simple/.travis.yml
@@ -27,6 +27,10 @@ env:
     init: /sbin/init
     run_opts: ""
   - distribution: Debian
+    distribution_version: stretch
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Debian
     distribution_version: jessie
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"

--- a/docs/examples/with-variables/.travis.yml
+++ b/docs/examples/with-variables/.travis.yml
@@ -33,6 +33,11 @@ env:
     init: /sbin/init
     run_opts: ""
   - distribution: Debian
+    distribution_version: stretch
+    version: "1"
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Debian
     distribution_version: jessie
     version: "1"
     init: /lib/systemd/systemd


### PR DESCRIPTION
Add documentation informations about debian 9 (stretch) version of the images.

Please also note that the debian-9 tag is missing in the automated builds produced on docker hub.

Thanks.