### PR TITLE
Clean Debian 8 (jessie) build

### DIFF
--- a/core/Debian/jessie/Dockerfile
+++ b/core/Debian/jessie/Dockerfile
@@ -11,12 +11,14 @@ RUN apt-get update \
        libssl-dev \
        python-pip \
        python-dev \
+       python-wheel \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \
     && rm -Rf /usr/share/man \
     && apt-get clean \
     && pip install --upgrade pip \
-    && pip install \
+# now using new pip version installed in /usr/local/bin
+    && /usr/local/bin/pip install \
         ansible \
         cryptography \
     && mkdir -p /etc/ansible \


### PR DESCRIPTION
Install python-wheel to use new PyPI binary distribution.
Also fix pip call using new installed version in /usr/local/bin/

This way not all python packages are binary compiled. Unfortunally cryptography module need to compile against local libssl-dev so we cannot remove the build-essentials requirements.