### PR TITLE
Add ca-certificates to Debian Wheezy

### DIFF
--- a/core/Debian/jessie/Dockerfile
+++ b/core/Debian/jessie/Dockerfile
@@ -11,12 +11,14 @@ RUN apt-get update \
        libssl-dev \
        python-pip \
        python-dev \
+       python-wheel \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \
     && rm -Rf /usr/share/man \
     && apt-get clean \
     && pip install --upgrade pip \
-    && pip install \
+# now using new pip version installed in /usr/local/bin
+    && /usr/local/bin/pip install \
         ansible \
         cryptography \
     && mkdir -p /etc/ansible \

--- a/core/Debian/wheezy/Dockerfile
+++ b/core/Debian/wheezy/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Christopher Davenport
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        sudo \
+       ca-certificates \
        build-essential \
        libffi-dev \
        libssl-dev \


### PR DESCRIPTION
Install ca-certificates package to Debian Wheezy image.
This is needed by ansible-galaxy to get roles from global service.