### PR TITLE
Add ca-certificates to Debian Wheezy

### DIFF
--- a/core/Debian/wheezy/Dockerfile
+++ b/core/Debian/wheezy/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Christopher Davenport
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        sudo \
+       ca-certificates \
        build-essential \
        libffi-dev \
        libssl-dev \


### PR DESCRIPTION
Add ca-certificates on Debian Wheezy images.
This is needed to pull role from galaxy.ansible.com that use https.