### PR TITLE
WIP: Convert source installation build to MultiStage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,90 +4,90 @@ services:
   - docker
 
 env:
-  - distribution: Ubuntu
-    distribution_version: yakkety
-    init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: Ubuntu
-    distribution_version: xenial
-    init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: Ubuntu
-    distribution_version: trusty
-    init: /sbin/init
-    run_opts: ""
-  - distribution: Ubuntu
-    distribution_version: precise
-    init: /sbin/init
-    run_opts: ""
-  - distribution: EL
-    distribution_version: "7"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: EL
-    distribution_version: "6"
-    init: /sbin/init
-    run_opts: ""
+  # - distribution: Ubuntu
+  #   distribution_version: yakkety
+  #   init: /lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: Ubuntu
+  #   distribution_version: xenial
+  #   init: /lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: Ubuntu
+  #   distribution_version: trusty
+  #   init: /sbin/init
+  #   run_opts: ""
+  # - distribution: Ubuntu
+  #   distribution_version: precise
+  #   init: /sbin/init
+  #   run_opts: ""
+  # - distribution: EL
+  #   distribution_version: "7"
+  #   init: /usr/lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: EL
+  #   distribution_version: "6"
+  #   init: /sbin/init
+  #   run_opts: ""
   - distribution: Debian
     distribution_version: stretch
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: Debian
-    distribution_version: jessie
-    init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: Debian
-    distribution_version: wheezy
-    init: /sbin/init
-    run_opts: ""
-  - distribution: Fedora
-    distribution_version: "24"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: Fedora
-    distribution_version: "23"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: ArchLinux
-    distribution_version: latest
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: OracleLinux
-    distribution_version: "7.3"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: OracleLinux
-    distribution_version: "7.2"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: OracleLinux
-    distribution_version: "7.1"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: OracleLinux
-    distribution_version: "7.0"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: OracleLinux
-    distribution_version: "6.8"
-    init: /sbin/init
-    run_opts: ""
-  - distribution: OracleLinux
-    distribution_version: "6.7"
-    init: /sbin/init
-    run_opts: ""
-  - distribution: OracleLinux
-    distribution_version: "6.6"
-    init: /sbin/init
-    run_opts: ""
-  - distribution: opensuse
-    distribution_version: "42.2"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: opensuse
-    distribution_version: "42.1"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: Debian
+  #   distribution_version: jessie
+  #   init: /lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: Debian
+  #   distribution_version: wheezy
+  #   init: /sbin/init
+  #   run_opts: ""
+  # - distribution: Fedora
+  #   distribution_version: "24"
+  #   init: /usr/lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: Fedora
+  #   distribution_version: "23"
+  #   init: /usr/lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: ArchLinux
+  #   distribution_version: latest
+  #   init: /usr/lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: OracleLinux
+  #   distribution_version: "7.3"
+  #   init: /usr/lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: OracleLinux
+  #   distribution_version: "7.2"
+  #   init: /usr/lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: OracleLinux
+  #   distribution_version: "7.1"
+  #   init: /usr/lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: OracleLinux
+  #   distribution_version: "7.0"
+  #   init: /usr/lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: OracleLinux
+  #   distribution_version: "6.8"
+  #   init: /sbin/init
+  #   run_opts: ""
+  # - distribution: OracleLinux
+  #   distribution_version: "6.7"
+  #   init: /sbin/init
+  #   run_opts: ""
+  # - distribution: OracleLinux
+  #   distribution_version: "6.6"
+  #   init: /sbin/init
+  #   run_opts: ""
+  # - distribution: opensuse
+  #   distribution_version: "42.2"
+  #   init: /usr/lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  # - distribution: opensuse
+  #   distribution_version: "42.1"
+  #   init: /usr/lib/systemd/systemd
+  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,90 +4,90 @@ services:
   - docker
 
 env:
-  # - distribution: Ubuntu
-  #   distribution_version: yakkety
-  #   init: /lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: Ubuntu
-  #   distribution_version: xenial
-  #   init: /lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: Ubuntu
-  #   distribution_version: trusty
-  #   init: /sbin/init
-  #   run_opts: ""
-  # - distribution: Ubuntu
-  #   distribution_version: precise
-  #   init: /sbin/init
-  #   run_opts: ""
-  # - distribution: EL
-  #   distribution_version: "7"
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: EL
-  #   distribution_version: "6"
-  #   init: /sbin/init
-  #   run_opts: ""
+  - distribution: Ubuntu
+    distribution_version: yakkety
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Ubuntu
+    distribution_version: xenial
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Ubuntu
+    distribution_version: trusty
+    init: /sbin/init
+    run_opts: ""
+  - distribution: Ubuntu
+    distribution_version: precise
+    init: /sbin/init
+    run_opts: ""
+  - distribution: EL
+    distribution_version: "7"
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: EL
+    distribution_version: "6"
+    init: /sbin/init
+    run_opts: ""
   - distribution: Debian
     distribution_version: stretch
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: Debian
-  #   distribution_version: jessie
-  #   init: /lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: Debian
-  #   distribution_version: wheezy
-  #   init: /sbin/init
-  #   run_opts: ""
-  # - distribution: Fedora
-  #   distribution_version: "24"
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: Fedora
-  #   distribution_version: "23"
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: ArchLinux
-  #   distribution_version: latest
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: OracleLinux
-  #   distribution_version: "7.3"
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: OracleLinux
-  #   distribution_version: "7.2"
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: OracleLinux
-  #   distribution_version: "7.1"
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: OracleLinux
-  #   distribution_version: "7.0"
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: OracleLinux
-  #   distribution_version: "6.8"
-  #   init: /sbin/init
-  #   run_opts: ""
-  # - distribution: OracleLinux
-  #   distribution_version: "6.7"
-  #   init: /sbin/init
-  #   run_opts: ""
-  # - distribution: OracleLinux
-  #   distribution_version: "6.6"
-  #   init: /sbin/init
-  #   run_opts: ""
-  # - distribution: opensuse
-  #   distribution_version: "42.2"
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  # - distribution: opensuse
-  #   distribution_version: "42.1"
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Debian
+    distribution_version: jessie
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Debian
+    distribution_version: wheezy
+    init: /sbin/init
+    run_opts: ""
+  - distribution: Fedora
+    distribution_version: "24"
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: Fedora
+    distribution_version: "23"
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: ArchLinux
+    distribution_version: latest
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: OracleLinux
+    distribution_version: "7.3"
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: OracleLinux
+    distribution_version: "7.2"
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: OracleLinux
+    distribution_version: "7.1"
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: OracleLinux
+    distribution_version: "7.0"
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: OracleLinux
+    distribution_version: "6.8"
+    init: /sbin/init
+    run_opts: ""
+  - distribution: OracleLinux
+    distribution_version: "6.7"
+    init: /sbin/init
+    run_opts: ""
+  - distribution: OracleLinux
+    distribution_version: "6.6"
+    init: /sbin/init
+    run_opts: ""
+  - distribution: opensuse
+    distribution_version: "42.2"
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: opensuse
+    distribution_version: "42.1"
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,9 @@ env:
   #   init: /usr/lib/systemd/systemd
   #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 script:
   - docker build -t ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" core/"${distribution}"/"${distribution_version}"

--- a/core/Debian/jessie/Dockerfile
+++ b/core/Debian/jessie/Dockerfile
@@ -1,26 +1,33 @@
-FROM debian:jessie-backports
+FROM debian:jessie-backports as builder
 MAINTAINER Christopher Davenport
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        apt-utils \
     && apt-get install -y --no-install-recommends \
-       sudo \
        build-essential \
        libffi-dev \
        libssl-dev \
        python-pip \
        python-dev \
        python-wheel \
+    && pip install --upgrade pip \
+    && /usr/local/bin/pip install \
+       ansible \
+       cryptography
+
+FROM debian:jessie-backports
+COPY --from=builder /usr/local/ /usr/local/
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       sudo \
+       libffi6 \
+       python \
+       ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \
     && rm -Rf /usr/share/man \
     && apt-get clean \
-    && pip install --upgrade pip \
-# now using new pip version installed in /usr/local/bin
-    && /usr/local/bin/pip install \
-        ansible \
-        cryptography \
     && mkdir -p /etc/ansible \
     && echo "[local]" > /etc/ansible/hosts \
     && echo "localhost ansible_connection=local" >> /etc/ansible/hosts

--- a/core/Debian/stretch/Dockerfile
+++ b/core/Debian/stretch/Dockerfile
@@ -1,10 +1,8 @@
-FROM debian:stretch
+FROM debian:stretch as builder
 MAINTAINER Christopher Davenport
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       systemd-sysv \
-       sudo \
        build-essential \
        libffi-dev \
        libssl-dev \
@@ -12,14 +10,24 @@ RUN apt-get update \
        python-dev \
        python-setuptools \
        python-wheel \
+    && pip install --upgrade pip \
+    && pip install \
+        ansible \
+        cryptography
+
+FROM debian:stretch
+COPY --from=builder /usr/local/ /usr/local/
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       systemd-sysv \
+       sudo \
+       libffi6 \
+       python \
+       ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \
     && rm -Rf /usr/share/man \
     && apt-get clean \
-    && pip install --upgrade pip \
-    && pip install \
-        ansible \
-        cryptography \
     && mkdir -p /etc/ansible \
     && echo "[local]" > /etc/ansible/hosts \
     && echo "localhost ansible_connection=local" >> /etc/ansible/hosts

--- a/core/Debian/wheezy/Dockerfile
+++ b/core/Debian/wheezy/Dockerfile
@@ -1,23 +1,31 @@
-FROM debian:wheezy-backports
+FROM debian:wheezy-backports as builder
 MAINTAINER Christopher Davenport
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       sudo \
        ca-certificates \
        build-essential \
        libffi-dev \
        libssl-dev \
        python-pip \
        python-dev \
+    && /usr/bin/pip install --upgrade pip \
+    && /usr/local/bin/pip install \
+       ansible \
+       cryptography
+
+FROM debian:wheezy-backports
+COPY --from=builder /usr/local/ /usr/local/
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      sudo \
+      libffi5 \
+      python \
+      ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \
     && rm -Rf /usr/share/man \
     && apt-get clean \
-    && /usr/bin/pip install --upgrade pip \
-    && /usr/local/bin/pip install \
-        ansible \
-        cryptography \
     && mkdir -p /etc/ansible \
     && echo "[local]" > /etc/ansible/hosts \
     && echo "localhost ansible_connection=local" >> /etc/ansible/hosts


### PR DESCRIPTION
This Feature allow to greatly reduce the size of the docker images generated with mutlistage build. This is very efficient for source build images (debian ones).

 image | after | before 
--------- | ------ | --------
wheezy| 179MB |420MB
 jessie | 219MB | 355MB
 stretch | 201MB | 473MB

Thanks docker (https://docs.docker.com/engine/userguide/eng-image/multistage-build/)

PS: need docker-ce >= 17.06, so I've update it in .travis.yml to make tests OK.