### PR TITLE
Add ansible-lint and yamllint

### DIFF
--- a/core/ArchLinux/latest/Dockerfile
+++ b/core/ArchLinux/latest/Dockerfile
@@ -1,7 +1,8 @@
 FROM archlinux/base
 MAINTAINER Christopher Davenport
 
-RUN pacman -Sy --needed --noconfirm sudo which systemd ansible \
+RUN pacman -Sy --needed --noconfirm sudo which systemd \
+      ansible ansible-lint yamllint \
     && sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers \
     && echo "[local]" > /etc/ansible/hosts \
     && echo "localhost ansible_connection=local" >> /etc/ansible/hosts

--- a/core/Debian/jessie/Dockerfile
+++ b/core/Debian/jessie/Dockerfile
@@ -14,7 +14,9 @@ RUN apt-get update \
     && pip install --upgrade pip \
     && /usr/local/bin/pip install \
        ansible \
-       cryptography
+       cryptography \
+       yamllint \
+       ansible-lint
 
 FROM debian:jessie-backports
 COPY --from=builder /usr/local/ /usr/local/
@@ -23,6 +25,7 @@ RUN apt-get update \
        sudo \
        libffi6 \
        python \
+       python-six \
        ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \

--- a/core/Debian/stretch/Dockerfile
+++ b/core/Debian/stretch/Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get update \
     # && pip install --upgrade pip \
     && pip install \
         ansible \
-        cryptography
+        cryptography \
+        yamllint \
+        ansible-lint
 
 FROM debian:stretch
 COPY --from=builder /usr/local/ /usr/local/

--- a/core/EL/6/Dockerfile
+++ b/core/EL/6/Dockerfile
@@ -9,9 +9,16 @@ RUN yum makecache fast \
     && yum -y update \
     && yum -y install \
         ansible \
+        ansible-lint \
         sudo \
         which \
-    && yum clean all \
+        python34 \
+    && yum clean all
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3 get-pip.py \
+    && pip install \
+      yamllint \
     && sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers \
     && echo "[local]" > /etc/ansible/hosts \
     && echo "localhost ansible_connection=local" >> /etc/ansible/hosts

--- a/core/EL/7/Dockerfile
+++ b/core/EL/7/Dockerfile
@@ -18,6 +18,8 @@ RUN   yum -y update; yum clean all; \
     && yum -y update \
     && yum -y install \
         ansible \
+        ansible-lint \
+        yamllint \
         sudo \
         which \
     && yum clean all \

--- a/core/Ubuntu/bionic/Dockerfile
+++ b/core/Ubuntu/bionic/Dockerfile
@@ -1,22 +1,36 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic as builder
 MAINTAINER Christopher Davenport
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libffi-dev \
+        libssl-dev \
+        python3-pip \
+        python3-dev \
+        python3-setuptools \
+        python3-wheel \
+    && pip3 install \
+        ansible \
+        cryptography \
+        yamllint \
+        ansible-lint
+
+FROM ubuntu:bionic
+COPY --from=builder /usr/local/ /usr/local/
 # Install Bundle And Clean Excess
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       software-properties-common \
-    && apt-add-repository -y ppa:ansible/ansible \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-       ansible \
-       rsyslog \
-       systemd \
-       systemd-cron \
-       sudo \
+        python3 \
+        rsyslog \
+        systemd \
+        systemd-cron \
+        sudo \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \
     && rm -Rf /usr/share/man \
     && touch -m -t 200101010101.01 /var/lib/apt/periodic/update-success-stamp \
     && apt-get clean \
-    && echo "[local]" > etc/ansible/hosts \
+    && mkdir -p /etc/ansible \
+    && echo "[local]" > /etc/ansible/hosts \
     && echo "localhost ansible_connection=local" >> /etc/ansible/hosts

--- a/core/Ubuntu/bionic/Dockerfile
+++ b/core/Ubuntu/bionic/Dockerfile
@@ -31,6 +31,5 @@ RUN apt-get update \
     && rm -Rf /usr/share/man \
     && touch -m -t 200101010101.01 /var/lib/apt/periodic/update-success-stamp \
     && apt-get clean \
-    && mkdir -p /etc/ansible \
-    && echo "[local]" > /etc/ansible/hosts \
-    && echo "localhost ansible_connection=local" >> /etc/ansible/hosts
+    && mkdir -p /etc/ansible
+COPY hosts /etc/ansible/

--- a/core/Ubuntu/bionic/hosts
+++ b/core/Ubuntu/bionic/hosts
@@ -1,0 +1,4 @@
+[local]
+localhost ansible_connection=local
+[local:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/core/Ubuntu/xenial/Dockerfile
+++ b/core/Ubuntu/xenial/Dockerfile
@@ -1,23 +1,37 @@
-FROM ubuntu:xenial
+FROM ubuntu:xenial as builder
 MAINTAINER Christopher Davenport
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libffi-dev \
+        libssl-dev \
+        python3-pip \
+        python3-dev \
+        python3-setuptools \
+        python3-wheel \
+    # && pip install --upgrade pip \
+    && pip3 install \
+        ansible \
+        cryptography \
+        yamllint \
+        ansible-lint
+
+FROM ubuntu:xenial
+COPY --from=builder /usr/local/ /usr/local/
 # Install Bundle And Clean Excess
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       software-properties-common \
-       python-software-properties \
-    && apt-add-repository -y ppa:ansible/ansible \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-       ansible \
-       rsyslog \
-       systemd \
-       systemd-cron \
-       sudo \
+        python3 \
+        rsyslog \
+        systemd \
+        systemd-cron \
+        sudo \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \
     && rm -Rf /usr/share/man \
     && touch -m -t 200101010101.01 /var/lib/apt/periodic/update-success-stamp \
     && apt-get clean \
-    && echo "[local]" > etc/ansible/hosts \
+    && mkdir -p /etc/ansible \
+    && echo "[local]" > /etc/ansible/hosts \
     && echo "localhost ansible_connection=local" >> /etc/ansible/hosts

--- a/core/Ubuntu/xenial/Dockerfile
+++ b/core/Ubuntu/xenial/Dockerfile
@@ -32,6 +32,5 @@ RUN apt-get update \
     && rm -Rf /usr/share/man \
     && touch -m -t 200101010101.01 /var/lib/apt/periodic/update-success-stamp \
     && apt-get clean \
-    && mkdir -p /etc/ansible \
-    && echo "[local]" > /etc/ansible/hosts \
-    && echo "localhost ansible_connection=local" >> /etc/ansible/hosts
+    && mkdir -p /etc/ansible
+COPY hosts /etc/ansible/

--- a/core/Ubuntu/xenial/hosts
+++ b/core/Ubuntu/xenial/hosts
@@ -1,0 +1,4 @@
+[local]
+localhost ansible_connection=local
+[local:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/docs/examples/simple-playbook/.travis.yml
+++ b/docs/examples/simple-playbook/.travis.yml
@@ -47,8 +47,15 @@ script:
   # Start The Built Container In The Background
   - 'docker run --detach --volume="${PWD}":/etc/ansible/playbooks:ro ${run_opts} ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" "${init}" > "${container_id}"'
 
+  # Install requirements, Uncomment if needed
+  # - 'docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=true ansible-galaxy install -v -r /etc/ansible/roles/role_under_test/requirements.yml'
+
   # Ansible syntax check.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/playbooks/tests/test.yml --syntax-check'
+
+  # Run linters
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-lint /etc/ansible/roles/role_under_test/tasks/main.yml'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm yamllint /etc/ansible/roles/role_under_test/'
 
   # Test role.
   - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/playbooks/tests/test.yml'

--- a/docs/examples/simple/.travis.yml
+++ b/docs/examples/simple/.travis.yml
@@ -47,8 +47,15 @@ script:
   # Start The Built Container In The Background
   - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" "${init}" > "${container_id}"'
 
+  # Install requirements, Uncomment if needed
+  # - 'docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=true ansible-galaxy install -v -r /etc/ansible/roles/role_under_test/requirements.yml'
+
   # Ansible syntax check.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
+
+  # Run linters
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-lint /etc/ansible/roles/role_under_test/tasks/main.yml'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm yamllint /etc/ansible/roles/role_under_test/'
 
   # Test role.
   - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'

--- a/docs/examples/with-variables/.travis.yml
+++ b/docs/examples/with-variables/.travis.yml
@@ -71,8 +71,15 @@ script:
   # Start The Built Container In The Background
   - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" "${init}" > "${container_id}"'
 
+  # Install requirements, Uncomment if needed
+  # - 'docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=true ansible-galaxy install -v -r /etc/ansible/roles/role_under_test/requirements.yml'
+
   # Ansible syntax check.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
+
+  # Run linters
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-lint /etc/ansible/roles/role_under_test/tasks/main.yml'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm yamllint /etc/ansible/roles/role_under_test/'
 
   # Test role.
   - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --extra-vars="role_version=${version}" '

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,17 +1,28 @@
 ---
 - hosts: localhost
-  pre_tasks:
-    - name: Update apt cache.
-      apt:
-        update_cache: yes
-      changed_when: False
-      when: ansible_os_family == 'Debian'
   tasks:
 
     - name: Check Ansible Is Installed
-      command: /usr/bin/env ansible --version
+      command: ansible --version
       register: reg_ansible_version
       changed_when: False
 
-    - name: Current Ansible Version
-      debug: var=reg_ansible_version
+    - name: Check Ansible-lint Is Installed
+      command: ansible-lint --version
+      register: reg_ansible_lint_version
+      changed_when: False
+
+    - name: Check Yamllint Is Installed
+      command: yamllint --version
+      register: reg_yamllint_version
+      changed_when: False
+
+    - name: Ansible Installed version
+      debug:
+        msg: "Ansible: {{ reg_ansible_version.stdout_lines[0] }}"
+    - name: Ansible-lint Installed version
+      debug:
+        msg: "Ansible-lint: {{ reg_ansible_lint_version.stdout }}"
+    - name: Yamllint Installed version
+      debug:
+        msg: "Yamllint: {{ reg_yamllint_version.stderr }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,15 +7,19 @@
       register: reg_ansible_version
       changed_when: False
 
+# ansible-lint is not installed on all distro
     - name: Check Ansible-lint Is Installed
       command: ansible-lint --version
       register: reg_ansible_lint_version
       changed_when: False
+      ignore_errors: true
 
+# yamllint is not installed on all distro
     - name: Check Yamllint Is Installed
       command: yamllint --version
       register: reg_yamllint_version
       changed_when: False
+      ignore_errors: true
 
     - name: Ansible Installed version
       debug:
@@ -23,6 +27,8 @@
     - name: Ansible-lint Installed version
       debug:
         msg: "Ansible-lint: {{ reg_ansible_lint_version.stdout }}"
+      when: reg_ansible_lint_version.failed == false
     - name: Yamllint Installed version
       debug:
         msg: "Yamllint: {{ reg_yamllint_version.stderr }}"
+      when: reg_yamllint_version.failed == false


### PR DESCRIPTION
Add those 2 linters to the images.

This allow to process roles and check for errors before building.
This is now also checked by ansible galaxy to assign score to roles.

ansible-lint and yamllint are only available on up2date distribution which are:
  - Debian 8 / 9
  - Ubuntu bionic / xenial
  - ArchLinux latest
  - CentOS/EL 6/7