### PR TITLE
Move docker image build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   - docker build -t "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" core/"${distribution}"/"${distribution_version}"
   - container_id=$(mktemp)
   # Start The Built Container In The Background
-  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" "${init}" > "${container_id}"'
+  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" "${init}" > "${container_id}"'
 
   # Ansible syntax check.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,4 +78,4 @@ deploy:
   skip_cleanup: true
   script: bash pushtoregistry.sh
   on:
-    branch: travis-build
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,64 +1,68 @@
 sudo: required
-language: python
+language: minimal
+dist: xenial
 services:
   - docker
 
 env:
-  - distribution: Ubuntu
-    distribution_version: bionic
-    distribution_alias: 18.04
-    init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: Ubuntu
-    distribution_version: xenial
-    distribution_alias: 16.04
-    init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: EL
-    distribution_version: "7"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: EL
-    distribution_version: "6"
-    init: /sbin/init
-    run_opts: ""
-  - distribution: Debian
-    distribution_version: stretch
-    distribution_alias: 9
-    init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: Debian
-    distribution_version: jessie
-    distribution_alias: 8
-    init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: Fedora
-    distribution_version: "24"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: ArchLinux
-    distribution_version: latest
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: OracleLinux
-    distribution_version: "7.3"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distribution: OracleLinux
-    distribution_version: "6.8"
-    init: /sbin/init
-    run_opts: ""
-  - distribution: opensuse
-    distribution_version: "42.2"
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  global:
+    - DOCKER_IMAGE_SLUG: $TRAVIS_REPO_SLUG
+  matrix:
+    - distribution: Ubuntu
+      distribution_version: bionic
+      distribution_alias: 18.04
+      init: /lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - distribution: Ubuntu
+      distribution_version: xenial
+      distribution_alias: 16.04
+      init: /lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - distribution: EL
+      distribution_version: "7"
+      init: /usr/lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - distribution: EL
+      distribution_version: "6"
+      init: /sbin/init
+      run_opts: ""
+    - distribution: Debian
+      distribution_version: stretch
+      distribution_alias: 9
+      init: /lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - distribution: Debian
+      distribution_version: jessie
+      distribution_alias: 8
+      init: /lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - distribution: Fedora
+      distribution_version: "24"
+      init: /usr/lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - distribution: ArchLinux
+      distribution_version: latest
+      init: /usr/lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - distribution: OracleLinux
+      distribution_version: "7.3"
+      init: /usr/lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - distribution: OracleLinux
+      distribution_version: "6.8"
+      init: /sbin/init
+      run_opts: ""
+    - distribution: opensuse
+      distribution_version: "42.2"
+      init: /usr/lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
 before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 script:
-  - docker build -t ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" core/"${distribution}"/"${distribution_version}"
+  - docker build -t "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" core/"${distribution}"/"${distribution_version}"
   - container_id=$(mktemp)
   # Start The Built Container In The Background
   - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" "${init}" > "${container_id}"'
@@ -71,9 +75,7 @@ script:
 
 deploy:
   provider: script
-  script:
-    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - if [[ $distribution_alias ]] && docker tag ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_alias}"
-    - docker push ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}"
+  skip_cleanup: true
+  script: bash pushtoregistry.sh
   on:
     branch: travis-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 env:
   global:
-    - DOCKER_IMAGE_SLUG: $TRAVIS_REPO_SLUG
+    - DOCKER_IMAGE_SLUG: "${TRAVIS_REPO_SLUG,,}"
   matrix:
     - distribution: Ubuntu
       distribution_version: bionic
@@ -76,6 +76,6 @@ script:
 deploy:
   provider: script
   skip_cleanup: true
-  script: bash pushtoregistry.sh
+  script: bash -e pushtoregistry.sh
   on:
     branch: travis-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ services:
 env:
   - distribution: Ubuntu
     distribution_version: bionic
+    distribution_alias: 18.04
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distribution: Ubuntu
     distribution_version: xenial
+    distribution_alias: 16.04
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distribution: EL
@@ -22,10 +24,12 @@ env:
     run_opts: ""
   - distribution: Debian
     distribution_version: stretch
+    distribution_alias: 9
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distribution: Debian
     distribution_version: jessie
+    distribution_alias: 8
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distribution: Fedora
@@ -65,18 +69,11 @@ script:
   # Test role.
   - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
 
-  # Test Idempotence
-  - idempotence=$(mktemp)
-  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
-  - >
-    tail ${idempotence}
-    | grep -q 'changed=0.*failed=0'
-    && (echo 'Idempotence test: pass' && exit 0)
-    || (echo 'Idempotence test: fail' && exit 1)
-
 deploy:
   provider: script
   script:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    - if [[ $distribution_alias ]] && docker tag ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_alias}"
+    - docker push ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}"
   on:
-    branch: master
+    branch: travis-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,6 @@ script:
 deploy:
   provider: script
   skip_cleanup: true
-  script: bash -e pushtoregistry.sh
+  script: bash pushtoregistry.sh
   on:
     branch: travis-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,3 +73,10 @@ script:
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
+
+deploy:
+  provider: script
+  script:
+    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  on:
+    branch: master

--- a/pushtoregistry.sh
+++ b/pushtoregistry.sh
@@ -1,7 +1,11 @@
 #!/bin/env bash
 
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker push "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}"
-[[ $distribution_alias ]] && \
-  docker tag "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_alias}" \
+set -v -x
+
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin &&
+docker push "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" &&
+[[ $distribution_alias ]] &&
+  {
+  docker tag "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_alias}" \ &&
   docker push "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_alias}"
+}

--- a/pushtoregistry.sh
+++ b/pushtoregistry.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker push "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}"
+[[ $distribution_alias ]] && \
+  docker tag "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_alias}" \
+  docker push "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_alias}"

--- a/pushtoregistry.sh
+++ b/pushtoregistry.sh
@@ -6,6 +6,6 @@ echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin &&
 docker push "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" &&
 [[ $distribution_alias ]] &&
   {
-  docker tag "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_alias}" \ &&
+  docker tag "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_alias}" &&
   docker push "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_alias}"
 }

--- a/pushtoregistry.sh
+++ b/pushtoregistry.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/env bash
 
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 docker push "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}"
 [[ $distribution_alias ]] && \
-  docker tag "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_alias}" \
+  docker tag "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_version}" "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_alias}" \
   docker push "${DOCKER_IMAGE_SLUG}":"${distribution,,}"-"${distribution_alias}"


### PR DESCRIPTION
This PR change the way docker images are build.

Instead of using the docker hub they are now builded and pushed by travis-ci directly.

Image are however only push to hub.docker.com when master is building and image build is OK.

This avoid configuration duplication of builds between travis check and docker hub. Moreover due to infra migrations all the docker build configuration got lost...

This way there is no diff between the travis images build and informations in them and the real images available.