### PR TITLE
Add ca-certificates to ubuntu containers

### DIFF
--- a/core/Ubuntu/bionic/Dockerfile
+++ b/core/Ubuntu/bionic/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
         systemd \
         systemd-cron \
         sudo \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \
     && rm -Rf /usr/share/man \

--- a/core/Ubuntu/xenial/Dockerfile
+++ b/core/Ubuntu/xenial/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
         systemd \
         systemd-cron \
         sudo \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc \
     && rm -Rf /usr/share/man \


### PR DESCRIPTION
Latest images remove openssl and ca-certificates which are needed for a lot of ansible modules